### PR TITLE
Make os.makedirs python2 compatible

### DIFF
--- a/src/VVM/gen_vvm.py
+++ b/src/VVM/gen_vvm.py
@@ -996,7 +996,8 @@ def main(output_directory):
     auto_gen_msg = common_msg % argv0
 
     # run through all headers
-    os.makedirs(output_directory, exist_ok=True)
+    if not os.path.exists(output_directory):
+        os.makedirs(output_directory)
     c = ChainOfWriters(auto_gen_msg, output_directory)
     c.run(TypesWriter('types.h'),
           OpcodesWriter('opcodes.h'),


### PR DESCRIPTION
On (my) ubuntu 18.04 Python 2.7 is used by default in `src/VVM/gen_vvm.py`. Python 2.7 `os.makedirs()` doesn't know about `exist_ok` which is easily fixed with a conditional.