### PR TITLE
Make loading from filepaths more robust

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
  *
  */
 
+#include <cstdlib>
 #include <iostream>
 #include <unordered_map>
 
@@ -45,6 +46,10 @@ std::string eval_asm(const std::string& text, bool dump_vvm = false) {
 
 // read an entire file's contents
 std::string read_file(std::string filename) {
+  filename = trim(filename);
+  if (starts_with(filename, "~")) {
+    filename = std::getenv("HOME") + filename.erase(0, 1);
+  }
   std::ifstream file(filename);
   if (!file) {
     throw std::runtime_error("Error: unable to read " + filename);

--- a/src/string_helpers.hpp
+++ b/src/string_helpers.hpp
@@ -29,6 +29,12 @@ bool ends_with(const std::string& left, const std::string& right) {
   return false;
 }
 
+std::string trim(std::string str) {
+  size_t start = str.find_first_not_of(" \t\n");
+  size_t end = str.find_last_not_of(" \t\n");
+  return str.substr(start, end - start + 1);
+}
+
 // contains pair of testable input and expected output
 struct TestPair {
   std::string in;


### PR DESCRIPTION
Replaces `~` by `std::getenv("HOME")` and trims the path before use.

Fix #5 