### PR TITLE
Fixed ANTLR bug that was causing parse error to result in crash

### DIFF
--- a/scripts/gh_update.sh
+++ b/scripts/gh_update.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Update my GitHub repo; optionally remove a branch
+
+git checkout master
+
+if [[ $1 != "" ]];
+then
+  git push --delete origin $1
+  git branch -D $1
+fi
+
+git pull upstream master
+git push origin master
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,10 @@ add_test(NAME test_ops
          COMMAND ${CMAKE_BINARY_DIR}/${EXECUTABLE} --verify-markdown ops.md
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_test(NAME test_err
+         COMMAND ${CMAKE_BINARY_DIR}/${EXECUTABLE} --verify-markdown err.md
+         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
 # TODO need a Windows version of the test script
 if(NOT WIN32)
 add_test(NAME test_emp

--- a/tests/err.md
+++ b/tests/err.md
@@ -1,0 +1,56 @@
+These tests cover error reporting.
+
+### Preliminary setup
+
+```
+>>> let prices = load$("sample_csv/prices.csv")
+
+>>> var my_int = 0
+
+```
+
+### Parse errors
+
+```
+>>> 'Hello'
+Error: character must have exactly one item
+
+>>> join prices, events on symbol on name
+Error: 'on' already listed
+
+```
+
+These messages should be improved.
+
+```
+>>> from prices select where symbol == "AAPL", volume > 30000000
+Error: unable to parse
+
+```
+
+### Type errors
+
+```
+>>> 1 + 2.
+Error: unable to match overloaded function +
+  candidate: (Int64, Int64) -> Int64
+    argument type at position 1 does not match: Float64 vs Int64
+  candidate: (Float64, Float64) -> Float64
+    argument type at position 0 does not match: Int64 vs Float64
+  candidate: (Int64, [Int64]) -> [Int64]
+    argument type at position 1 does not match: Float64 vs [Int64]
+  ...
+  <45 others>
+
+>>> my_int = 7.
+Error: mismatched types in assignment: Int64 vs Float64
+
+```
+
+### Identifier errors
+
+```
+>>> my_float = 0.0
+Error: symbol my_float was not found
+
+```


### PR DESCRIPTION
This applies the following patch to ANTLR:

```
diff --git a/runtime/Cpp/runtime/src/NoViableAltException.cpp b/runtime/Cpp/runtime/src/NoViableAltException.cpp
index ced7f82..75bec5d 100755
--- a/runtime/Cpp/runtime/src/NoViableAltException.cpp
+++ b/runtime/Cpp/runtime/src/NoViableAltException.cpp
@@ -21,8 +21,6 @@ NoViableAltException::NoViableAltException(Parser *recognizer, TokenStream *inpu
 }
 
 NoViableAltException::~NoViableAltException() {
-  if (_deleteConfigs)
-    delete _deadEndConfigs;
 }
 
 Token* NoViableAltException::getStartToken() const {
@@ -30,5 +28,5 @@ Token* NoViableAltException::getStartToken() const {
 }
 
 atn::ATNConfigSet* NoViableAltException::getDeadEndConfigs() const {
-  return _deadEndConfigs;
+  return _deadEndConfigs.get();
 }
diff --git a/runtime/Cpp/runtime/src/NoViableAltException.h b/runtime/Cpp/runtime/src/NoViableAltException.h
index 94d43c5..f3f1fe7 100755
--- a/runtime/Cpp/runtime/src/NoViableAltException.h
+++ b/runtime/Cpp/runtime/src/NoViableAltException.h
@@ -27,7 +27,7 @@ namespace antlr4 {
 
   private:
     /// Which configurations did we try at input.index() that couldn't match input.LT(1)?
-    atn::ATNConfigSet* _deadEndConfigs;
+    std::shared_ptr<atn::ATNConfigSet> _deadEndConfigs;
 
     // Flag that indicates if we own the dead end config set and have to delete it on destruction.
     bool _deleteConfigs;
```

fixes #2 